### PR TITLE
Fixed script failure with bigint-ids in source and target fields of e…

### DIFF
--- a/src/topology/sql/create_vertices_table.sql
+++ b/src/topology/sql/create_vertices_table.sql
@@ -70,7 +70,7 @@ DECLARE
     sourcename text;
     targetname text;
     query text;
-    ecnt integer; 
+    ecnt bigint; 
     srid integer;
     sourcetype text;
     targettype text;


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-
-
-

@pgRouting/admins

…dge_table

Since source and target values can be bitint values and in line 235 the script puts the biggest value of id to ecnt, ecnt should also from type bigint.